### PR TITLE
Test demo_opts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Full documentation with installation instructions can be found in:
 * https://luma-oled.readthedocs.io
 * https://luma-lcd.readthedocs.io
 * https://luma-led-matrix.readthedocs.io
-* https://luma-core.readthedocs.io (coming soon)
-* https://luma-emulator.readthedocs.io (coming soon)
+* https://luma-core.readthedocs.io
+* https://luma-emulator.readthedocs.io
 
 License
 -------

--- a/conf/st7735.conf
+++ b/conf/st7735.conf
@@ -1,0 +1,8 @@
+--display=st7735
+--interface=spi
+--spi-bus-speed=32000000
+--bcm-reset=24
+--bcm-data-command=23
+--bcm-backlight=18
+--width=160
+--height=128

--- a/examples/3d_box.py
+++ b/examples/3d_box.py
@@ -14,7 +14,7 @@ http://codentronix.com/2011/05/12/rotating-3d-cube-using-python-and-pygame/
 import sys
 import math
 from operator import itemgetter
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from luma.core.sprite_system import framerate_regulator
 
@@ -127,6 +127,7 @@ def main(num_iterations=sys.maxsize):
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/bounce.py
+++ b/examples/bounce.py
@@ -13,7 +13,8 @@ Attribution: https://github.com/rogerdahl/ssd1306/blob/master/examples/bounce.py
 import sys
 import random
 
-from demo_opts import device
+from demo_opts import get_device
+
 import luma.core.render
 from luma.core.sprite_system import framerate_regulator
 
@@ -77,6 +78,7 @@ def main(num_iterations=sys.maxsize):
 
 if __name__ == '__main__':
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/carousel.py
+++ b/examples/carousel.py
@@ -17,7 +17,7 @@ Needs psutil (+ dependencies) installed::
 
 import psutil
 
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.virtual import viewport, snapshot
 
 from hotspot import memory, uptime, cpu_load, clock, network, disk
@@ -106,6 +106,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/chroma.py
+++ b/examples/chroma.py
@@ -11,7 +11,7 @@ import math
 import time
 import colorsys
 
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 
 
@@ -179,6 +179,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/clock.py
+++ b/examples/clock.py
@@ -66,7 +66,7 @@ def main():
 
 if __name__ == "__main__":
     try:
-	device = get_device()
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/clock.py
+++ b/examples/clock.py
@@ -14,7 +14,7 @@ https://gist.github.com/TheRayTracer/dd12c498e3ecb9b8b47f#file-clock-py
 import math
 import time
 import datetime
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 
 
@@ -66,6 +66,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+	device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -12,7 +12,7 @@ import math
 import time
 import random
 import os.path
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from PIL import Image
 
@@ -82,6 +82,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/crawl.py
+++ b/examples/crawl.py
@@ -10,7 +10,7 @@ A vertical scrolling demo, which should be familiar.
 
 import time
 import os.path
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.virtual import viewport
 from luma.core.render import canvas
 from PIL import Image
@@ -85,6 +85,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -13,7 +13,7 @@ https://github.com/adafruit/Adafruit_Python_SSD1306/blob/master/examples/shapes.
 
 import time
 import datetime
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 
 
@@ -94,6 +94,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -118,7 +118,6 @@ def get_device(actual_args=None):
 
             device = Device(serial, width=args.width, height=args.height,
                             rotate=args.rotate, mode=args.mode)
-            return device
 
         elif args.display in display_types.get('lcd'):
             # luma.lcd
@@ -133,7 +132,6 @@ def get_device(actual_args=None):
                 bcm_RST=args.bcm_reset)
             luma.lcd.device.backlight(bcm_LIGHT=args.bcm_backlight).enable(True)
             device = Device(serial, rotate=args.rotate)
-            return device
 
         elif args.display in display_types.get('led_matrix'):
             # luma.led_matrix
@@ -146,8 +144,7 @@ def get_device(actual_args=None):
                 bus_speed_hz=args.spi_bus_speed,
                 gpio=noop())
             device = Device(serial, width=args.width, height=args.height,
-                            rotate=args.rotate, block_orientation=args.block_orientation)
-            return device
+                rotate=args.rotate, block_orientation=args.block_orientation)
 
         elif args.display in display_types.get('emulator'):
             # luma.emulator
@@ -155,7 +152,8 @@ def get_device(actual_args=None):
 
             Device = getattr(luma.emulator.device, args.display)
             device = Device(**vars(args))
-            return device
 
     except Error as e:
         parser.error(e)
+
+    return device

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -31,6 +31,7 @@ def load_config(fp):
 
     return args
 
+
 def create_parser():
     """
     Create command-line argument parser.
@@ -75,7 +76,7 @@ def get_device(actual_args=None):
     """
     if actual_args is None:
         actual_args = sys.argv[1:]
-    
+
     parser = create_parser()
     args = parser.parse_args(actual_args)
 

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -96,9 +96,6 @@ def get_device(actual_args=None):
 
     # find display and create device
     if args.display in display_types.get('oled'):
-        if args.interface not in interface_types:
-            parser.error('unknown interface %s' % args.interface)
-
         # luma.oled
         import luma.oled.device
         Device = getattr(luma.oled.device, args.display)

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -50,7 +50,7 @@ def create_parser(description='luma.examples arguments'):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('--config', '-f', type=str, help='Load configuration settings from a file')
-    parser.add_argument('--display', '-d', type=str, default='ssd1306', help='Display type, supports real devices or emulators', choices=display_choices)
+    parser.add_argument('--display', '-d', type=str, default=display_choices[0], help='Display type, supports real devices or emulators', choices=display_choices)
     parser.add_argument('--width', type=int, default=128, help='Width of the device in pixels')
     parser.add_argument('--height', type=int, default=64, help='Height of the device in pixels')
     parser.add_argument('--rotate', '-r', type=int, default=0, help='Rotation factor', choices=[0, 1, 2, 3])

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -54,7 +54,7 @@ def create_parser(description='luma.examples arguments'):
     parser.add_argument('--width', type=int, default=128, help='Width of the device in pixels')
     parser.add_argument('--height', type=int, default=64, help='Height of the device in pixels')
     parser.add_argument('--rotate', '-r', type=int, default=0, help='Rotation factor', choices=[0, 1, 2, 3])
-    parser.add_argument('--interface', '-i', type=str, default='i2c', help='Serial interface type', choices=interface_types)
+    parser.add_argument('--interface', '-i', type=str, default=interface_types[0], help='Serial interface type', choices=interface_types)
     parser.add_argument('--i2c-port', type=int, default=1, help='I2C bus number')
     parser.add_argument('--i2c-address', type=str, default='0x3C', help='I2C display address')
     parser.add_argument('--spi-port', type=int, default=0, help='SPI port number')

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -13,6 +13,15 @@ import argparse
 import luma.core.serial
 
 
+# logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)-15s - %(message)s'
+)
+# ignore PIL debug messages
+logging.getLogger('PIL').setLevel(logging.ERROR)
+
+
 def load_config(fp):
     args = []
     for line in fp.readlines():
@@ -22,105 +31,114 @@ def load_config(fp):
     return args
 
 
-parser = argparse.ArgumentParser(description='luma.examples arguments',
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+def get_device(args=None):
+    if args is None:
+        args = sys.argv[1:]
 
-parser.add_argument('--config', '-f', type=str, help='Load configuration settings from a file')
-parser.add_argument('--display', '-d', type=str, default='ssd1306', help='Display type, supports real devices or emulators', choices=["ssd1306", "ssd1322", "ssd1325", "ssd1331", "sh1106", "pcd8544", "max7219", "capture", "pygame", "gifanim"])
-parser.add_argument('--width', type=int, default=128, help='Width of the device in pixels')
-parser.add_argument('--height', type=int, default=64, help='Height of the device in pixels')
-parser.add_argument('--rotate', '-r', type=int, default=0, help='Rotation factor', choices=[0, 1, 2, 3])
-parser.add_argument('--interface', '-i', type=str, default='i2c', help='Serial interface type', choices=["i2c", "spi"])
-parser.add_argument('--i2c-port', type=int, default=1, help='I2C bus number')
-parser.add_argument('--i2c-address', type=str, default='0x3C', help='I2C display address')
-parser.add_argument('--spi-port', type=int, default=0, help='SPI port number')
-parser.add_argument('--spi-device', type=int, default=0, help='SPI device')
-parser.add_argument('--spi-bus-speed', type=int, default=8000000, help='SPI max bus speed (Hz)')
-parser.add_argument('--bcm-data-command', type=int, default=24, help='BCM pin for D/C RESET (SPI devices only)')
-parser.add_argument('--bcm-reset', type=int, default=25, help='BCM pin for RESET (SPI devices only)')
-parser.add_argument('--bcm-backlight', type=int, default=18, help='BCM pin for backlight (PCD8544 devices only)')
-parser.add_argument('--block-orientation', type=str, default='horizontal', help='Fix 90° phase error (MAX7219 LED matrix only)', choices=['horizontal', 'vertical'])
-parser.add_argument('--transform', type=str, default='scale2x', help='Scaling transform to apply (emulator only)', choices=["none", "identity", "scale2x", "smoothscale", "led_matrix", "seven_segment"])
-parser.add_argument('--scale', type=int, default=2, help='Scaling factor to apply (emulator only)')
-parser.add_argument('--mode', type=str, default='RGB', help='Colour mode (ssd1322, ssd1325 and emulator only)', choices=['1', 'RGB', 'RGBA'])
-parser.add_argument('--duration', type=float, default=0.01, help='Animation frame duration (gifanim emulator only)')
-parser.add_argument('--loop', type=int, default=0, help='Repeat loop, zero=forever (gifanim emulator only)')
-parser.add_argument('--max-frames', type=int, help='Maximum frames to record (gifanim emulator only)')
+    parser = argparse.ArgumentParser(description='luma.examples arguments',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-try:
-    import argcomplete
-    argcomplete.autocomplete(parser)
-except ImportError:
-    pass
+    parser.add_argument('--config', '-f', type=str, help='Load configuration settings from a file')
+    parser.add_argument('--display', '-d', type=str, default='ssd1306', help='Display type, supports real devices or emulators', choices=["ssd1306", "ssd1322", "ssd1325", "ssd1331", "sh1106", "pcd8544", "max7219", "capture", "pygame", "gifanim"])
+    parser.add_argument('--width', type=int, default=128, help='Width of the device in pixels')
+    parser.add_argument('--height', type=int, default=64, help='Height of the device in pixels')
+    parser.add_argument('--rotate', '-r', type=int, default=0, help='Rotation factor', choices=[0, 1, 2, 3])
+    parser.add_argument('--interface', '-i', type=str, default='i2c', help='Serial interface type', choices=["i2c", "spi"])
+    parser.add_argument('--i2c-port', type=int, default=1, help='I2C bus number')
+    parser.add_argument('--i2c-address', type=str, default='0x3C', help='I2C display address')
+    parser.add_argument('--spi-port', type=int, default=0, help='SPI port number')
+    parser.add_argument('--spi-device', type=int, default=0, help='SPI device')
+    parser.add_argument('--spi-bus-speed', type=int, default=8000000, help='SPI max bus speed (Hz)')
+    parser.add_argument('--bcm-data-command', type=int, default=24, help='BCM pin for D/C RESET (SPI devices only)')
+    parser.add_argument('--bcm-reset', type=int, default=25, help='BCM pin for RESET (SPI devices only)')
+    parser.add_argument('--bcm-backlight', type=int, default=18, help='BCM pin for backlight (PCD8544 devices only)')
+    parser.add_argument('--block-orientation', type=str, default='horizontal', help='Fix 90° phase error (MAX7219 LED matrix only)', choices=['horizontal', 'vertical'])
+    parser.add_argument('--transform', type=str, default='scale2x', help='Scaling transform to apply (emulator only)', choices=["none", "identity", "scale2x", "smoothscale", "led_matrix", "seven_segment"])
+    parser.add_argument('--scale', type=int, default=2, help='Scaling factor to apply (emulator only)')
+    parser.add_argument('--mode', type=str, default='RGB', help='Colour mode (ssd1322, ssd1325 and emulator only)', choices=['1', 'RGB', 'RGBA'])
+    parser.add_argument('--duration', type=float, default=0.01, help='Animation frame duration (gifanim emulator only)')
+    parser.add_argument('--loop', type=int, default=0, help='Repeat loop, zero=forever (gifanim emulator only)')
+    parser.add_argument('--max-frames', type=int, help='Maximum frames to record (gifanim emulator only)')
 
-# logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)-15s - %(message)s'
-)
-# ignore PIL debug messages
-logging.getLogger('PIL').setLevel(logging.ERROR)
-
-args = parser.parse_args()
-
-if args.config:
-    with open(args.config, "r") as fp:
-        config = load_config(fp)
-        args = parser.parse_args(config + sys.argv[1:])
-
-if args.display in ('ssd1306', 'ssd1322', 'ssd1325', 'ssd1331', 'sh1106'):
-    if args.interface not in ('i2c', 'spi'):
-        parser.error('unknown interface %s' % args.interface)
-
-    import luma.oled.device
-    Device = getattr(luma.oled.device, args.display)
     try:
-        if (args.interface == 'i2c'):
-            serial = luma.core.serial.i2c(port=args.i2c_port, address=args.i2c_address)
-        elif (args.interface == 'spi'):
+        import argcomplete
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
+
+    args = parser.parse_args()
+
+    if args.config:
+        with open(args.config, "r") as fp:
+            config = load_config(fp)
+            args = parser.parse_args(config + sys.argv[1:])
+
+    if args.display in ('ssd1306', 'ssd1322', 'ssd1325', 'ssd1331', 'sh1106'):
+        if args.interface not in ('i2c', 'spi'):
+            parser.error('unknown interface %s' % args.interface)
+
+        # luma.oled
+        import luma.oled.device
+        Device = getattr(luma.oled.device, args.display)
+        try:
+            if (args.interface == 'i2c'):
+                serial = luma.core.serial.i2c(port=args.i2c_port, address=args.i2c_address)
+            elif (args.interface == 'spi'):
+                serial = luma.core.serial.spi(port=args.spi_port,
+                                              device=args.spi_device,
+                                              bus_speed_hz=args.spi_bus_speed,
+                                              bcm_DC=args.bcm_data_command,
+                                              bcm_RST=args.bcm_reset)
+            device = Device(serial, width=args.width, height=args.height,
+                            rotate=args.rotate, mode=args.mode)
+            return device
+
+        except Exception as e:
+            parser.error(e)
+
+    elif args.display in ('pcd8544'):
+        # luma.lcd
+        import luma.lcd.device
+        Device = getattr(luma.lcd.device, args.display)
+        try:
             serial = luma.core.serial.spi(port=args.spi_port,
                                           device=args.spi_device,
                                           bus_speed_hz=args.spi_bus_speed,
                                           bcm_DC=args.bcm_data_command,
                                           bcm_RST=args.bcm_reset)
-        device = Device(serial, width=args.width, height=args.height,
-                        rotate=args.rotate, mode=args.mode)
-    except Exception as e:
-        parser.error(e)
+            luma.lcd.device.backlight(bcm_LIGHT=args.bcm_backlight).enable(True)
+            device = Device(serial, rotate=args.rotate)
+            return device
 
-elif args.display in ('pcd8544'):
-    import luma.lcd.device
-    Device = getattr(luma.lcd.device, args.display)
-    try:
-        serial = luma.core.serial.spi(port=args.spi_port,
-                                      device=args.spi_device,
-                                      bus_speed_hz=args.spi_bus_speed,
-                                      bcm_DC=args.bcm_data_command,
-                                      bcm_RST=args.bcm_reset)
-        luma.lcd.device.backlight(bcm_LIGHT=args.bcm_backlight).enable(True)
-        device = Device(serial, rotate=args.rotate)
+        except Exception as e:
+            parser.error(e)
 
-    except Exception as e:
-        parser.error(e)
+    elif args.display in ('max7219'):
+        # luma.led_matrix
+        import luma.led_matrix.device
+        Device = getattr(luma.led_matrix.device, args.display)
+        try:
+            serial = luma.core.serial.spi(port=args.spi_port,
+                                          device=args.spi_device,
+                                          bus_speed_hz=args.spi_bus_speed,
+                                          gpio=luma.core.serial.noop())
+            device = Device(serial, width=args.width, height=args.height,
+                            rotate=args.rotate, block_orientation=args.block_orientation)
+            return device
 
-elif args.display in ('max7219'):
-    import luma.led_matrix.device
-    Device = getattr(luma.led_matrix.device, args.display)
-    try:
-        serial = luma.core.serial.spi(port=args.spi_port,
-                                      device=args.spi_device,
-                                      bus_speed_hz=args.spi_bus_speed,
-                                      gpio=luma.core.serial.noop())
-        device = Device(serial, width=args.width, height=args.height,
-                        rotate=args.rotate, block_orientation=args.block_orientation)
+        except Exception as e:
+            parser.error(e)
 
-    except Exception as e:
-        parser.error(e)
+    elif args.display in ('capture', 'pygame', 'gifanim'):
+        # luma.emulator
+        import luma.emulator.device
+        Device = getattr(luma.emulator.device, args.display)
+        try:
+            device = Device(**vars(args))
+            return device
 
-elif args.display in ('capture', 'pygame', 'gifanim'):
-    import luma.emulator.device
-    Device = getattr(luma.emulator.device, args.display)
-    device = Device(**vars(args))
+        except Exception as e:
+            parser.error(e)
 
-else:
-    parser.error('unknown display %s' % args.display)
+    else:
+        parser.error('unknown display %s' % args.display)

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -21,6 +21,9 @@ logging.getLogger('PIL').setLevel(logging.ERROR)
 
 
 def load_config(fp):
+    """
+    Load device configuration from file.
+    """
     args = []
     for line in fp.readlines():
         if line.strip() and not line.startswith('#'):
@@ -28,11 +31,10 @@ def load_config(fp):
 
     return args
 
-
-def get_device(actual_args=None):
-    if actual_args is None:
-        actual_args = sys.argv[1:]
-
+def create_parser():
+    """
+    Create command-line argument parser.
+    """
     parser = argparse.ArgumentParser(description='luma.examples arguments',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
@@ -64,12 +66,23 @@ def get_device(actual_args=None):
     except ImportError:
         pass
 
+    return parser
+
+
+def get_device(actual_args=None):
+    """
+    Create and return the device.
+    """
+    if actual_args is None:
+        actual_args = sys.argv[1:]
+    
+    parser = create_parser()
     args = parser.parse_args(actual_args)
 
     if args.config:
         with open(args.config, "r") as fp:
             config = load_config(fp)
-            args = parser.parse_args(config + sys.argv[1:])
+            args = parser.parse_args(config + actual_args)
 
     if args.display in ('ssd1306', 'ssd1322', 'ssd1325', 'ssd1331', 'sh1106'):
         if args.interface not in ('i2c', 'spi'):

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -89,12 +89,12 @@ def get_device(actual_args=None):
     parser = create_parser()
     args = parser.parse_args(actual_args)
 
-    # parse config
     if args.config:
+        # load config from file
         config = load_config(args.config)
         args = parser.parse_args(config + actual_args)
 
-    # create device
+    # find display and create device
     if args.display in display_types.get('oled'):
         if args.interface not in interface_types:
             parser.error('unknown interface %s' % args.interface)

--- a/examples/game_of_life.py
+++ b/examples/game_of_life.py
@@ -13,7 +13,7 @@ http://codereview.stackexchange.com/a/108121
 
 import time
 from random import randint
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 
 
@@ -75,6 +75,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/greyscale.py
+++ b/examples/greyscale.py
@@ -10,7 +10,7 @@ Greyscale rendering demo.
 
 import time
 import os.path
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from PIL import Image
 
@@ -52,6 +52,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/invaders.py
+++ b/examples/invaders.py
@@ -14,10 +14,11 @@ https://gist.github.com/TheRayTracer/dd12c498e3ecb9b8b47f#file-invaders-py
 import os.path
 import time
 import random
-from demo_opts import device
+from demo_opts import get_device
 from PIL import Image
 from luma.core.render import canvas
 from luma.core.sprite_system import framerate_regulator
+
 
 arrow = [0x04, 0x02, 0x01, 0x02, 0x04]
 alien1 = [0x4C, 0x1A, 0xB6, 0x5F, 0x5F, 0xB6, 0x1A, 0x4C]
@@ -184,6 +185,8 @@ def ai_logic_move(army, plyr, rows):
 
 
 if __name__ == '__main__':
+
+    device = get_device()
 
     if device.size not in ((256, 64), (128, 64), (96, 64)):
         raise ValueError("Unsupported mode: {0}x{1}".format(device.width, device.height))

--- a/examples/jetset_willy.py
+++ b/examples/jetset_willy.py
@@ -7,7 +7,7 @@
 import sys
 import os.path
 from PIL import Image
-from demo_opts import device
+from demo_opts import get_device
 
 from luma.core.sprite_system import spritesheet, framerate_regulator
 
@@ -97,6 +97,7 @@ def main(num_iterations=sys.maxsize):
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/maze.py
+++ b/examples/maze.py
@@ -12,7 +12,7 @@ https://github.com/rm-hull/maze/blob/master/src/maze/generator.clj
 """
 
 import time
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from random import randrange
 
@@ -153,6 +153,7 @@ def demo(iterations):
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         demo(20)
     except KeyboardInterrupt:
         pass

--- a/examples/perfloop.py
+++ b/examples/perfloop.py
@@ -15,7 +15,7 @@ import sys
 import time
 from PIL import Image, ImageDraw
 
-from demo_opts import device
+from demo_opts import get_device
 import demo
 
 
@@ -64,4 +64,5 @@ def main():
 
 
 if __name__ == "__main__":
+    device = get_device()
     main()

--- a/examples/pi_logo.py
+++ b/examples/pi_logo.py
@@ -9,7 +9,7 @@ Display the Raspberry Pi logo (loads image as .png).
 """
 
 import os.path
-from demo_opts import device
+from demo_opts import get_device
 from PIL import Image
 
 
@@ -32,6 +32,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/picamera_photo.py
+++ b/examples/picamera_photo.py
@@ -17,7 +17,7 @@ import picamera
 
 from PIL import Image
 
-from demo_opts import device
+from demo_opts import get_device
 
 
 def main():
@@ -57,6 +57,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/picamera_video.py
+++ b/examples/picamera_video.py
@@ -18,7 +18,7 @@ import picamera
 
 from PIL import Image
 
-from demo_opts import device
+from demo_opts import get_device
 
 
 # create a pool of image processors
@@ -79,6 +79,7 @@ def streams():
 
 cameraResolution = (640, 480)
 cameraFrameRate = 8
+device = get_device()
 
 with picamera.PiCamera() as camera:
     pool = [ImageProcessor() for i in range(4)]

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -7,7 +7,7 @@
 import sys
 import os.path
 from PIL import Image
-from demo_opts import device
+from demo_opts import get_device
 
 from luma.core.sprite_system import spritesheet, framerate_regulator
 
@@ -63,6 +63,7 @@ def main(num_iterations=sys.maxsize):
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/savepoint.py
+++ b/examples/savepoint.py
@@ -9,7 +9,7 @@ Example of savepoint/restore functionality.
 """
 
 import time
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.virtual import history
 from luma.core.render import canvas
 
@@ -62,6 +62,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/scrolling_pixelart.py
+++ b/examples/scrolling_pixelart.py
@@ -12,7 +12,7 @@ from @pixel_dailies twitter feed.
 import time
 import random
 import os.path
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.virtual import viewport
 from PIL import Image
 
@@ -89,6 +89,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/sprite_animation.py
+++ b/examples/sprite_animation.py
@@ -10,7 +10,7 @@ Sprite animation
 
 import time
 import os.path
-from demo_opts import device
+from demo_opts import get_device
 from PIL import Image
 
 
@@ -68,6 +68,7 @@ def explosion():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         while True:
             mickey()
             explosion()

--- a/examples/starfield.py
+++ b/examples/starfield.py
@@ -12,7 +12,7 @@ http://codentronix.com/2011/05/28/3d-starfield-made-using-python-and-pygame/
 """
 
 from random import randrange
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 
 
@@ -69,6 +69,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/sys_info.py
+++ b/examples/sys_info.py
@@ -22,7 +22,7 @@ if os.name != 'posix':
 
 import psutil
 
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from PIL import ImageFont
 
@@ -102,6 +102,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/terminal.py
+++ b/examples/terminal.py
@@ -10,7 +10,7 @@ Simple println capabilities.
 
 import os
 import time
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.virtual import terminal
 from PIL import ImageFont
 
@@ -79,6 +79,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/examples/tv_snow.py
+++ b/examples/tv_snow.py
@@ -10,10 +10,12 @@ Example image-blitting.
 
 import struct
 import random
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from PIL import Image, ImageDraw
 
+
+device = get_device()
 size = (60, 30)
 # Calc offset to center text vertically and horizontally
 offset = ((device.width - size[0]) // 2, (device.height - size[1]) // 2)

--- a/examples/tweet_scroll.py
+++ b/examples/tweet_scroll.py
@@ -40,7 +40,7 @@ import time
 import tweepy
 from PIL import ImageFont
 
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.render import canvas
 from luma.core.virtual import viewport
 
@@ -87,6 +87,7 @@ class listener(tweepy.StreamListener):
         self.queue.put(status)
 
 
+device = get_device()
 auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
 auth.set_access_token(access_token, access_token_secret)
 api = tweepy.API(auth)

--- a/examples/welcome.py
+++ b/examples/welcome.py
@@ -10,7 +10,7 @@ Unicode font rendering & scrolling.
 
 import os
 import random
-from demo_opts import device
+from demo_opts import get_device
 from luma.core.virtual import viewport, snapshot, range_overlap
 from luma.core.sprite_system import framerate_regulator
 from PIL import ImageFont
@@ -225,6 +225,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        device = get_device()
         main()
     except KeyboardInterrupt:
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ exclude =
     __pycache__,
     doc,
     build,
-    dist
+    dist,
+    conf
 
 [aliases]
 test=pytest

--- a/tests/resources/config-test.txt
+++ b/tests/resources/config-test.txt
@@ -1,0 +1,4 @@
+--display=capture
+--width=800
+--height=8600
+--spi-bus-speed=16000000

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -3,6 +3,103 @@
 # Copyright (c) 2017 Richard Hull and contributors
 # See LICENSE.rst for details.
 
+import os
 
-def test_me():
-    assert 1 == 1
+import pytest
+
+import luma.emulator.device
+
+from demo_opts import load_config, get_device, create_parser
+
+
+config_file = os.path.join(os.path.dirname(__file__),
+    'resources', 'config-test.txt')
+
+
+def test_create_parser():
+    """
+    create_parser returns an argument parser instance.
+    """
+    parser = create_parser()
+    args = parser.parse_args(['-f', config_file])
+    assert args.config == config_file
+
+
+def test_load_config_parse():
+    """
+    load_config parses a text file and returns a list of arguments.
+    """
+    with open(config_file, "r") as fp:
+        result = load_config(fp)
+
+    assert result == [
+        '--display=capture',
+        '--width=800',
+        '--height=8600',
+        '--spi-bus-speed=16000000'
+    ]
+
+
+def test_get_device_missing_config():
+    """
+    Loading a missing config file throws an error.
+    """
+    with pytest.raises(IOError):
+        get_device(['-f', 'foo'])
+
+
+def test_get_device_good_config():
+    """
+    Loading a correct config file does not throw an error.
+    """
+    device = get_device(['-f', config_file])
+
+    assert isinstance(device, luma.emulator.device.capture)
+
+
+def test_get_device_unknown():
+    """
+    Load an unknown device.
+    """
+    with pytest.raises(SystemExit):
+        get_device(['--display', 'foo'])
+
+
+# luma.emulator
+
+def test_get_device_emulator_capture():
+    """
+    Load the 'capture' emulator device.
+    """
+    device = get_device(['--display', 'capture'])
+
+    assert isinstance(device, luma.emulator.device.capture)
+
+
+def test_get_device_emulator_pygame():
+    """
+    Load the 'pygame' emulator device.
+    """
+    device = get_device(['--display', 'pygame'])
+
+    assert isinstance(device, luma.emulator.device.pygame)
+
+
+def test_get_device_emulator_gifanim():
+    """
+    Load the 'gifanim' emulator device.
+    """
+    device = get_device(['--display', 'gifanim'])
+
+    assert isinstance(device, luma.emulator.device.gifanim)
+
+
+# luma.led_matrix
+
+def test_get_device_led_matrix_max7219():
+    """
+    Load the 'max7219' device.
+    """
+    #device = get_device(['--display', 'max7219'])
+
+    #assert isinstance(device, luma.emulator.device.gifanim)

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -3,7 +3,17 @@
 # Copyright (c) 2017 Richard Hull and contributors
 # See LICENSE.rst for details.
 
+"""
+Tests for the :py:mod:`demo_opts` module.
+"""
+
 import os
+import sys
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 import pytest
 
@@ -76,39 +86,28 @@ def test_get_device_unknown(capsys):
     """
     Load an unknown device.
     """
-    with pytest.raises(SystemExit):
-        get_device(['--display', 'foo'])
+    test_args = [__name__, '--display', 'foo']
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit):
+            get_device()
 
     assertInError("invalid choice: 'foo'", capsys)
 
 
 # luma.emulator
 
-def test_get_device_emulator_capture():
+def test_get_device_emulator_all():
     """
-    Load the 'capture' emulator device.
+    Load an emulator device.
     """
-    device = get_device(['--display', 'capture'])
-
-    assert isinstance(device, luma.emulator.device.capture)
-
-
-def test_get_device_emulator_pygame():
-    """
-    Load the 'pygame' emulator device.
-    """
-    device = get_device(['--display', 'pygame'])
-
-    assert isinstance(device, luma.emulator.device.pygame)
-
-
-def test_get_device_emulator_gifanim():
-    """
-    Load the 'gifanim' emulator device.
-    """
-    device = get_device(['--display', 'gifanim'])
-
-    assert isinstance(device, luma.emulator.device.gifanim)
+    emulators= {
+        'capture': luma.emulator.device.capture,
+        'pygame': luma.emulator.device.pygame,
+        'gifanim': luma.emulator.device.gifanim
+    }
+    for display, klass in emulators.items():
+        device = get_device(['--display', display])
+        assert isinstance(device, klass)
 
 
 # luma.led_matrix

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -100,7 +100,7 @@ def test_get_device_emulator_all():
     """
     Load an emulator device.
     """
-    emulators= {
+    emulators = {
         'capture': luma.emulator.device.capture,
         'pygame': luma.emulator.device.pygame,
         'gifanim': luma.emulator.device.gifanim

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -9,16 +9,27 @@ import pytest
 
 import luma.emulator.device
 
-from demo_opts import load_config, get_device, create_parser
+from demo_opts import (load_config, get_device, create_parser, display_types,
+    interface_types)
 
 
-config_file = os.path.join(os.path.dirname(__file__),
+test_config_file = os.path.join(os.path.dirname(__file__),
     'resources', 'config-test.txt')
 
 
 def assertInError(msg, capsys):
+    """
+    Helper to find text in argparse error output message.
+    """
     out, err = capsys.readouterr()
     assert msg in err
+
+
+def test_support():
+    """
+    Attributes available to check supported display types and interfaces.
+    """
+    assert interface_types == ["i2c", "spi"]
 
 
 def test_create_parser():
@@ -26,15 +37,15 @@ def test_create_parser():
     create_parser returns an argument parser instance.
     """
     parser = create_parser()
-    args = parser.parse_args(['-f', config_file])
-    assert args.config == config_file
+    args = parser.parse_args(['-f', test_config_file])
+    assert args.config == test_config_file
 
 
-def test_load_config_parse():
+def test_load_config_file_parse():
     """
     load_config parses a text file and returns a list of arguments.
     """
-    result = load_config(config_file)
+    result = load_config(test_config_file)
 
     assert result == [
         '--display=capture',
@@ -44,7 +55,7 @@ def test_load_config_parse():
     ]
 
 
-def test_get_device_missing_config():
+def test_get_device_config_file_missing():
     """
     Loading a missing config file throws an error.
     """
@@ -52,11 +63,11 @@ def test_get_device_missing_config():
         get_device(['-f', 'foo'])
 
 
-def test_get_device_good_config():
+def test_get_device_config__file_success():
     """
     Loading a correct config file does not throw an error.
     """
-    device = get_device(['-f', config_file])
+    device = get_device(['-f', test_config_file])
 
     assert isinstance(device, luma.emulator.device.capture)
 
@@ -102,11 +113,50 @@ def test_get_device_emulator_gifanim():
 
 # luma.led_matrix
 
-def test_get_device_led_matrix_max7219(capsys):
+def test_get_device_led_matrix_all(capsys):
     """
-    Load the 'max7219' device.
+    Load supported led_matrix devices one by one.
+    """
+    for display in display_types.get('led_matrix'):
+        with pytest.raises(SystemExit):
+            get_device(['--display', display])
+
+        assertInError('error: SPI device not found', capsys)
+
+
+# luma.lcd
+
+def test_get_device_lcd_all(capsys):
+    """
+    Load supported lcd devices one by one.
+    """
+    for display in display_types.get('lcd'):
+        with pytest.raises(SystemExit):
+            get_device(['--display', display])
+
+        assertInError('error: This module can only be run on a Raspberry Pi!\n',
+            capsys)
+
+
+# luma.oled
+
+def test_get_device_oled_all(capsys):
+    """
+    Load supported oled devices one by one.
+    """
+    for display in display_types.get('oled'):
+        with pytest.raises(SystemExit):
+            get_device(['--display', display])
+
+        assertInError('I2C device permission denied', capsys)
+
+
+def test_get_device_oled_interface_unknown(capsys):
+    """
+    Get oled device with unknown interface.
     """
     with pytest.raises(SystemExit):
-        get_device(['--display', 'max7219'])
+        get_device(['--display', 'ssd1306',
+            '--interface', 'foo'])
 
-    assertInError('error: SPI device not found', capsys)
+    assertInError("argument --interface/-i: invalid choice: 'foo'", capsys)

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -126,16 +126,17 @@ def test_get_device_led_matrix_all(capsys):
 
 # luma.lcd
 
-def test_get_device_lcd_all(capsys):
+def test_get_device_lcd_all():
     """
     Load supported lcd devices one by one.
     """
     for display in display_types.get('lcd'):
-        with pytest.raises(SystemExit):
+        # XXX: this should raise a normal SystemExit, see
+        # https://github.com/rm-hull/luma.lcd/issues/28
+        with pytest.raises(RuntimeError) as ex:
             get_device(['--display', display])
 
-        assertInError('error: This module can only be run on a Raspberry Pi!\n',
-            capsys)
+        assert str(ex.value) == 'This module can only be run on a Raspberry Pi!'
 
 
 # luma.oled

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -16,6 +16,11 @@ config_file = os.path.join(os.path.dirname(__file__),
     'resources', 'config-test.txt')
 
 
+def assertInError(msg, capsys):
+    out, err = capsys.readouterr()
+    assert msg in err
+
+
 def test_create_parser():
     """
     create_parser returns an argument parser instance.
@@ -29,8 +34,7 @@ def test_load_config_parse():
     """
     load_config parses a text file and returns a list of arguments.
     """
-    with open(config_file, "r") as fp:
-        result = load_config(fp)
+    result = load_config(config_file)
 
     assert result == [
         '--display=capture',
@@ -57,12 +61,14 @@ def test_get_device_good_config():
     assert isinstance(device, luma.emulator.device.capture)
 
 
-def test_get_device_unknown():
+def test_get_device_unknown(capsys):
     """
     Load an unknown device.
     """
     with pytest.raises(SystemExit):
         get_device(['--display', 'foo'])
+
+    assertInError("invalid choice: 'foo'", capsys)
 
 
 # luma.emulator
@@ -96,10 +102,11 @@ def test_get_device_emulator_gifanim():
 
 # luma.led_matrix
 
-def test_get_device_led_matrix_max7219():
+def test_get_device_led_matrix_max7219(capsys):
     """
     Load the 'max7219' device.
     """
-    #device = get_device(['--display', 'max7219'])
+    with pytest.raises(SystemExit):
+        get_device(['--display', 'max7219'])
 
-    #assert isinstance(device, luma.emulator.device.gifanim)
+    assertInError('error: SPI device not found', capsys)

--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -148,7 +148,7 @@ def test_get_device_oled_all(capsys):
         with pytest.raises(SystemExit):
             get_device(['--display', display])
 
-        assertInError('I2C device permission denied', capsys)
+        assertInError('I2C device', capsys)
 
 
 def test_get_device_oled_interface_unknown(capsys):

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
     PYTHONPATH = {toxinidir}/examples
 commands =
     python setup.py install
-    coverage run -m py.test -v
+    coverage run -m py.test -vv
     coverage report
 deps =
     .[test]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist = py{27,34,35,36,37},qa
 skip_missing_interpreters = True
 
 [testenv]
+setenv =
+    PYTHONPATH = {toxinidir}/examples
 commands =
     python setup.py install
     coverage run -m py.test -v


### PR DESCRIPTION
fixes #13

To make testing possible, the examples changed and instead of importing `device`, now use the `get_device` method.