### PR TITLE
print library version info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
         - python: 3.5
           env: TOXENV=qa
 
-install: pip install --ignore-installed --upgrade setuptools pip tox setuptools
+install: pip install --ignore-installed --upgrade setuptools pip tox
 script: tox -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
         - python: 3.5
           env: TOXENV=qa
 
-install: pip install -U pip tox setuptools
+install: pip install --ignore-installed --upgrade setuptools pip tox setuptools
 script: tox -vv

--- a/examples/demo_opts.py
+++ b/examples/demo_opts.py
@@ -28,8 +28,18 @@ def display_settings(args):
     if args.display not in display_types['emulator']:
         iface = 'Interface: {}\n'.format(args.interface)
 
-    return 'Display: {}\n{}Dimensions: {} x {}\n{}'.format(
-        args.display, iface, args.width, args.height, '-' * 40)
+    lib_name = cmdline.get_library_for_display_type(args.display)
+    if lib_name is not None:
+        lib_version = cmdline.get_library_version(lib_name)
+    else:
+        lib_name = lib_version = 'unknown'
+
+    import luma.core
+    version = 'luma.{} {} (luma.core {})'.format(
+        lib_name, lib_version, luma.core.__version__)
+
+    return 'Version: {}\nDisplay: {}\n{}Dimensions: {} x {}\n{}'.format(
+        version, args.display, iface, args.width, args.height, '-' * 60)
 
 
 def get_device(actual_args=None):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords="raspberry orange banana pi rpi opi sbc oled lcd led display screen spi i2c",
     url="https://github.com/rm-hull/luma.examples",
     install_requires=[
-        "luma.core>=1.2.0",
+        "luma.core>=1.2.1",
         "luma.emulator>=1.0.2",
         "luma.oled>=2.3.1",
         "luma.lcd>=1.0.3",

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ setup(
     keywords="raspberry orange banana pi rpi opi sbc oled lcd led display screen spi i2c",
     url="https://github.com/rm-hull/luma.examples",
     install_requires=[
-        "luma.core>=1.1.0",
-        "luma.emulator>=1.0.0",
-        "luma.oled>=2.2.5",
-        "luma.lcd>=1.0.0",
-        "luma.led_matrix>=1.0.2",
+        "luma.core>=1.2.0",
+        "luma.emulator>=1.0.2",
+        "luma.oled>=2.3.1",
+        "luma.lcd>=1.0.3",
+        "luma.led_matrix>=1.0.6",
         "argcomplete"
     ],
     setup_requires=pytest_runner,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "luma.emulator>=1.0.2",
         "luma.oled>=2.3.1",
         "luma.lcd>=1.0.3",
-        "luma.led_matrix>=1.0.6",
+        "luma.led_matrix>=1.0.7",
         "argcomplete"
     ],
     setup_requires=pytest_runner,

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ skip_missing_interpreters = True
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}/examples
+    SDL_VIDEODRIVER = dummy
 commands =
     python setup.py install
     coverage run -m py.test -vv -r wsx


### PR DESCRIPTION
The example startup print now includes library version nrs, e.g.:

```
Version: luma.superhdscreenz 1.2.3 (luma.core 4.5.6)
Display: Awesome display
Interface: USB
Dimensions: 120 x 80
------------------------------------------------------------
```