### PR TITLE
Change: iteritems -> items (Python 3 compatibility)

### DIFF
--- a/examples/image_composition.py
+++ b/examples/image_composition.py
@@ -46,7 +46,7 @@ class Synchroniser():
         self.synchronised[id(task)] = True
 
     def is_synchronised(self):
-        for task in self.synchronised.iteritems():
+        for task in self.synchronised.items():
             if task[1] is False:
                 return False
         return True


### PR DESCRIPTION
Iteritems has been removed from Python 3, the script will now work with Python 2 and 3 (Although items is a bit slower then iteritems in Python 2)