### PR TITLE
LED matrix devices must now specify interface on command line

### DIFF
--- a/tests/test_demo_opts.py
+++ b/tests/test_demo_opts.py
@@ -119,7 +119,7 @@ def test_get_device_led_matrix_all(capsys):
     """
     for display in cmdline.get_display_types().get('led_matrix'):
         try:
-            get_device(['--display', display])
+            get_device(['--display', display, '--interface', 'spi'])
         except SystemExit:
             assertInError('SPI device not found', capsys)
         except ImportError as e:


### PR DESCRIPTION
After introduction of FTDI wrapper. 

The conf/max7291.conf file already had this, so it was just the test that needed amending