### PR TITLE
 Added IP info to sys_info.py

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,3 +20,4 @@ Contributors
 * Tomislav Kopić (@Tkopic001)
 * Maciej Sokolowski (@matemaciek)
 * Sangho Kim (@rlaace423)
+* Breno RdV (@brenordv)

--- a/examples/sys_info.py
+++ b/examples/sys_info.py
@@ -61,7 +61,7 @@ class IPAddressChecker:
                 return s.getsockname()[0]
         except Exception as e:
             print(f"Error: {e}")
-            return None
+            return ""
 
 
 def bytes2human(n):


### PR DESCRIPTION
Added IP info to the `sys_info.py` example. Also included a caching (default: 4 hours) since IP address is not something that changes frequently.

If something goes wrong, the line will be blank.

The rationale for this change is that the IP being displayed is super useful information to have at hand and goes well with all the other stats printed in this example.