### PR TITLE
Update video.py

### DIFF
--- a/examples/video.py
+++ b/examples/video.py
@@ -35,8 +35,8 @@ def main():
 
     clip = av.open(video_path)
 
-    for frame in clip.decode(video=0):
-        print(f'{frame.index} ------')
+    for i, frame in enumerate(clip.decode(video=0)):
+        print(f'{i} ------')
 
         img = frame.to_image()
         if img.width != device.width or img.height != device.height:


### PR DESCRIPTION
Fix for `AttributeError: 'av.video.frame.VideoFrame' object has no attribute 'index'` error

{frame.index} only exist in packet and container streams and not in decoded frames.

Implemented manual counter.